### PR TITLE
hotfix to fix the rendering: disable the last cell

### DIFF
--- a/src/exercises/probmod_1-intro.jl
+++ b/src/exercises/probmod_1-intro.jl
@@ -346,6 +346,8 @@ Side note: the code is wrapped in a `let` block so Pluto won't complain about th
 """
 
 # ╔═╡ 51f9b6f9-9415-4030-82a6-32f9742bf7f5
+# ╠═╡ disabled = true
+#=╠═╡
 let
 	n_samples = 1000
 
@@ -372,6 +374,7 @@ let
 	scatter(sp_x, sp_y, group = vec(sp_dists2 .<= 1),
 		legend = false, aspect_ratio = :equal) # which is nice for plotting
 end
+  ╠═╡ =#
 
 # ╔═╡ Cell order:
 # ╟─aeb0aef0-b2ee-11ef-3cca-7f80b487ea17


### PR DESCRIPTION
I have no idea why this works, but it does.
My best guess is something dank with Turing in this part of the code:

```julia
dist_chain = sample(dist_model, Prior(), n_samples);
sp_dists2 = generated_quantities(dist_model, dist_chain);
sp_x = dist_chain[:x] # this method allows recovery of stochastic variables
sp_y = dist_chain[:y]
scatter(sp_x, sp_y, group = vec(sp_dists2 .<= 1),
legend = false, aspect_ratio = :equal) # which is nice for plotting
```

It is not essential for the notebooks, just some summary at the end, so I think we are good to go.

CI is green, site can be build