### PR TITLE
remove `OrdinaryDiffEq` imports from P3

### DIFF
--- a/exercises/solved_notebooks/P3_sde/sde_model_aging_mtk_sol.jl
+++ b/exercises/solved_notebooks/P3_sde/sde_model_aging_mtk_sol.jl
@@ -11,7 +11,7 @@ using Pkg; Pkg.activate("..")
 using Markdown, InteractiveUtils
 
 # ╔═╡ 1d0a8fb2-dab9-44ae-a230-f3e92cf3cd6a
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ 7a9fa5bc-7bb3-436e-b796-b946c855fe0a
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/solved_notebooks/P3_sde/sde_model_fermenter_secondorder_mtk_sol.jl
+++ b/exercises/solved_notebooks/P3_sde/sde_model_fermenter_secondorder_mtk_sol.jl
@@ -11,7 +11,7 @@ using Pkg; Pkg.activate("..")
 using Markdown, InteractiveUtils
 
 # ╔═╡ e317c2cc-c41a-4489-b06b-7f07a517e20b
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ 2e91e92c-5cd2-4018-8a26-9f0f9e01a175
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/solved_notebooks/P3_sde/sde_model_heston_mtk_intro.jl
+++ b/exercises/solved_notebooks/P3_sde/sde_model_heston_mtk_intro.jl
@@ -14,7 +14,7 @@ using Markdown, InteractiveUtils
 using StatsPlots, StatsBase
 
 # ╔═╡ 7e450e64-a8d6-47e9-9c2a-8bf8a4e2e71e
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ d1185b3f-5fa3-4d84-9a7f-c105b7c456ac
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/solved_notebooks/P3_sde/ssa_model_bike_sharing_sol.jl
+++ b/exercises/solved_notebooks/P3_sde/ssa_model_bike_sharing_sol.jl
@@ -26,7 +26,7 @@ using Markdown
 using InteractiveUtils
 
 # ╔═╡ 71140c81-af29-4857-8020-4f94c8bd64b3
-using Catalyst, OrdinaryDiffEq, JumpProcesses, StatsPlots, StatsBase
+using Catalyst, JumpProcesses, StatsPlots, StatsBase
 
 # ╔═╡ 284f5847-9c15-41f3-a595-1e12a22df69f
 using PlutoUI; TableOfContents()

--- a/exercises/solved_notebooks/P3_sde/ssa_model_catalyst_intro.jl
+++ b/exercises/solved_notebooks/P3_sde/ssa_model_catalyst_intro.jl
@@ -17,7 +17,7 @@ using PlutoUI; TableOfContents()
 using Catalyst
 
 # ╔═╡ 0b3921c9-6d6e-4c52-8c21-d883ed493028
-using OrdinaryDiffEq, JumpProcesses, StatsPlots
+using JumpProcesses, StatsPlots
 
 # ╔═╡ 62b185be-e327-4ef3-af39-819732d107bf
 md"""

--- a/exercises/solved_notebooks/P3_sde/ssa_model_festival_toilet_sol.jl
+++ b/exercises/solved_notebooks/P3_sde/ssa_model_festival_toilet_sol.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg; Pkg.activate("..")
 
 # ╔═╡ e84131d2-3ad2-11f0-02b8-2ffac00498cf
-using Catalyst, StatsPlots, OrdinaryDiffEq, JumpProcesses
+using Catalyst, StatsPlots, JumpProcesses
 
 # ╔═╡ 0ab79c4e-0206-47e1-b057-3f84e4f66a17
 using PlutoUI; TableOfContents()

--- a/exercises/student_notebooks/P3_sde/sde_model_aging_mtk.jl
+++ b/exercises/student_notebooks/P3_sde/sde_model_aging_mtk.jl
@@ -11,7 +11,7 @@ using Pkg; Pkg.activate("..")
 using Markdown, InteractiveUtils
 
 # ╔═╡ 1d0a8fb2-dab9-44ae-a230-f3e92cf3cd6a
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ 7a9fa5bc-7bb3-436e-b796-b946c855fe0a
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/student_notebooks/P3_sde/sde_model_fermenter_secondorder_mtk.jl
+++ b/exercises/student_notebooks/P3_sde/sde_model_fermenter_secondorder_mtk.jl
@@ -11,7 +11,7 @@ using Pkg; Pkg.activate("..")
 using Markdown, InteractiveUtils
 
 # ╔═╡ e317c2cc-c41a-4489-b06b-7f07a517e20b
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ 2e91e92c-5cd2-4018-8a26-9f0f9e01a175
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/student_notebooks/P3_sde/sde_model_heston_mtk_intro.jl
+++ b/exercises/student_notebooks/P3_sde/sde_model_heston_mtk_intro.jl
@@ -14,7 +14,7 @@ using Markdown, InteractiveUtils
 using StatsPlots, StatsBase
 
 # ╔═╡ 7e450e64-a8d6-47e9-9c2a-8bf8a4e2e71e
-using ModelingToolkit, OrdinaryDiffEq, StochasticDiffEq
+using ModelingToolkit, StochasticDiffEq
 
 # ╔═╡ d1185b3f-5fa3-4d84-9a7f-c105b7c456ac
 using ModelingToolkit: t_nounits as t, D_nounits as D

--- a/exercises/student_notebooks/P3_sde/ssa_model_bike_sharing.jl
+++ b/exercises/student_notebooks/P3_sde/ssa_model_bike_sharing.jl
@@ -26,7 +26,7 @@ using Markdown
 using InteractiveUtils
 
 # ╔═╡ 71140c81-af29-4857-8020-4f94c8bd64b3
-using Catalyst, OrdinaryDiffEq, JumpProcesses, StatsPlots, StatsBase
+using Catalyst, JumpProcesses, StatsPlots, StatsBase
 
 # ╔═╡ 284f5847-9c15-41f3-a595-1e12a22df69f
 using PlutoUI; TableOfContents()

--- a/exercises/student_notebooks/P3_sde/ssa_model_catalyst_intro.jl
+++ b/exercises/student_notebooks/P3_sde/ssa_model_catalyst_intro.jl
@@ -17,7 +17,7 @@ using PlutoUI; TableOfContents()
 using Catalyst
 
 # ╔═╡ 0b3921c9-6d6e-4c52-8c21-d883ed493028
-using OrdinaryDiffEq, JumpProcesses, StatsPlots
+using JumpProcesses, StatsPlots
 
 # ╔═╡ 62b185be-e327-4ef3-af39-819732d107bf
 md"""

--- a/exercises/student_notebooks/P3_sde/ssa_model_festival_toilet.jl
+++ b/exercises/student_notebooks/P3_sde/ssa_model_festival_toilet.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 using Pkg; Pkg.activate("..")
 
 # ╔═╡ e84131d2-3ad2-11f0-02b8-2ffac00498cf
-using Catalyst, StatsPlots, OrdinaryDiffEq, JumpProcesses
+using Catalyst, StatsPlots, JumpProcesses
 
 # ╔═╡ 0ab79c4e-0206-47e1-b057-3f84e4f66a17
 using PlutoUI; TableOfContents()


### PR DESCRIPTION
Unnecessary imports as all P3 notebooks use either `StochasticDiffEq` or `JumpProcesses`